### PR TITLE
Change button text to "Edit My Order" on submitted page

### DIFF
--- a/src/routes/submitted/+page.svelte
+++ b/src/routes/submitted/+page.svelte
@@ -53,7 +53,7 @@
   </article>
 
   <p>
-    <a href="/" role="button" class="secondary">Edit My Order</a>
+    <a href="/" role="button" class="secondary">← Edit My Order</a>
   </p>
 {:else}
   <p>You haven't ordered any items yet.</p>

--- a/src/routes/submitted/+page.svelte
+++ b/src/routes/submitted/+page.svelte
@@ -53,7 +53,7 @@
   </article>
 
   <p>
-    <a href="/" role="button" class="secondary">Update My Order</a>
+    <a href="/" role="button" class="secondary">Edit My Order</a>
   </p>
 {:else}
   <p>You haven't ordered any items yet.</p>


### PR DESCRIPTION
Changes the ambiguous "Update My Order" button text to "Edit My Order" on the submitted page.

The previous text was causing users to think they needed to click it to confirm their order, when it's actually only needed for making modifications.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)